### PR TITLE
✨ Add finalization flexibility

### DIFF
--- a/src/CommitmentManager.sol
+++ b/src/CommitmentManager.sol
@@ -11,13 +11,18 @@ contract CommitmentManager {
     /// @dev The gas limit for the `areAccountCommitmentsSatisfiedByValue` function.
     uint256 public immutable ACCOUNT_COMMITMENTS_GAS_LIMIT;
 
+    /// @dev The amount of seconds required to pass before a commitment is finalized.
+    uint256 public immutable FINALIZATION;
+
     /// @dev A mapping of account addresses to a mapping of target hashes to an array of commitments.
     mapping(address => mapping(bytes32 => Commitment[])) public commitments;
 
     /// @dev Constructor function that sets the `ACCOUNT_COMMITMENTS_GAS_LIMIT`.
     /// @param accountCommitmentsGasLimit The gas limit for the `areAccountCommitmentsSatisfiedByValue` function.
-    constructor(uint256 accountCommitmentsGasLimit) {
+    /// @param finalization_ The amount of seconds required to pass before a commitment is finalized.
+    constructor(uint256 accountCommitmentsGasLimit, uint256 finalization_) {
         ACCOUNT_COMMITMENTS_GAS_LIMIT = accountCommitmentsGasLimit;
+        FINALIZATION = finalization_;
     }
 
     /// @dev Function that creates a new commitment for the calling account and target.
@@ -67,7 +72,7 @@ contract CommitmentManager {
         bytes calldata value,
         uint256 upToTimestamp
     ) public view returns (bool) {
-        return commitments_.areCommitmentsSatisfiedByValue(value, upToTimestamp);
+        return commitments_.areCommitmentsSatisfiedByValue(value, upToTimestamp, FINALIZATION);
     }
 
     /// @dev Function that returns an array of commitments made by an account to a target.

--- a/src/lib/Lib.sol
+++ b/src/lib/Lib.sol
@@ -9,14 +9,17 @@ library CommitmentsLib {
     /// @notice Checks if commitments are satisfied by a value.
     /// @param commitments An array of commitments.
     /// @param value The value to check against the commitments.
+    /// @param upToTimestamp The timestamp to check against.
+    /// @param finalization The amount of seconds required to pass before a commitment is finalized.
     /// @return A boolean indicating whether the array of commitments is satisfied by the value.
     function areCommitmentsSatisfiedByValue(
         Commitment[] memory commitments,
         bytes calldata value,
-        uint256 upToTimestamp
+        uint256 upToTimestamp,
+        uint256 finalization
     ) public view returns (bool) {
         for (uint256 i = 0; i < commitments.length; i++) {
-            if (isFinalizedByTimestamp(commitments[i], upToTimestamp)) {
+            if (isFinalizedByTimestamp(commitments[i], upToTimestamp, finalization)) {
                 (bool success, bytes memory data) = commitments[i].indicatorFunction.address.staticcall(
                     abi.encodeWithSelector(commitments[i].indicatorFunction.selector, value)
                 );
@@ -31,14 +34,16 @@ library CommitmentsLib {
 
     /// @notice Checks if a commitment is finalized.
     /// @param commitment The commitment to check.
+    /// @param timestamp The timestamp to check against.
+    /// @param finalization The amount of seconds required to pass before a commitment is finalized.
     /// @return finalized A boolean indicating whether the commitment is finalized.
-    function isFinalizedByTimestamp(Commitment memory commitment, uint256 timestamp)
+    function isFinalizedByTimestamp(Commitment memory commitment, uint256 timestamp, uint256 finalization)
         public
         pure
         returns (bool finalized)
     {
         // We take a commitment as finalized if it was made more than an epoch ago, where an epoch is 7 minutes (consensus)
         // Ideally, we'll use something more robust.
-        return timestamp - commitment.timestamp > 7 minutes;
+        return timestamp - commitment.timestamp > finalization;
     }
 }

--- a/test/CommitmentManager.t.sol
+++ b/test/CommitmentManager.t.sol
@@ -13,7 +13,7 @@ contract CommitmentManagerTest is Test {
     Handler public handler;
 
     function setUp() public {
-        manager = new CommitmentManager(10000);
+        manager = new CommitmentManager(10000, 7 minutes);
         handler = new Handler(manager);
 
         bytes4[] memory selectors = new bytes4[](2);
@@ -55,7 +55,7 @@ contract CommitmentManagerTest is Test {
         Commitment[] memory commitments = manager.getCommitments(account, target);
 
         for (uint256 i = 0; i < commitments.length; i++) {
-            if (CommitmentsLib.isFinalizedByTimestamp(commitments[i], upToTimestamp)) {
+            if (CommitmentsLib.isFinalizedByTimestamp(commitments[i], upToTimestamp, 7 minutes)) {
                 (bool success, bytes memory data) = commitments[i].indicatorFunction.address.staticcall(
                     abi.encodeWithSelector(commitments[i].indicatorFunction.selector, value)
                 );
@@ -73,7 +73,7 @@ contract CommitmentManagerTest is Test {
         Commitment[] memory commitments = manager.getCommitments(account, target);
 
         for (uint256 i = 0; i < commitments.length; i++) {
-            if (CommitmentsLib.isFinalizedByTimestamp(commitments[i], upToTimestamp)) {
+            if (CommitmentsLib.isFinalizedByTimestamp(commitments[i], upToTimestamp, 7 minutes)) {
                 (bool success, bytes memory data) = commitments[i].indicatorFunction.address.staticcall(
                     abi.encodeWithSelector(commitments[i].indicatorFunction.selector, value)
                 );

--- a/test/CommitmentPBS.t.sol
+++ b/test/CommitmentPBS.t.sol
@@ -14,7 +14,7 @@ contract CommitmentPBSTest is Test {
 
     function setUp() public {
         pbs = new CommitmentPBS();
-        pbs.setCommitmentManager(address(manager = new CommitmentManager(10000)));
+        pbs.setCommitmentManager(address(manager = new CommitmentManager(10000, 7 minutes)));
         handler = new Handler(pbs);
 
         bytes4[] memory selectors = new bytes4[](2);


### PR DESCRIPTION
The finalization of a commitment is fixed to 7 minutes, which is a lot of time for fast networks and over-complicates working with Anvil. This PR introduces a new storage variable that allows to set the seconds required for finalization on contract creation. The tests are updated to use the original 7 minutes.